### PR TITLE
Custom text sizing

### DIFF
--- a/source/fluid/code_input.d
+++ b/source/fluid/code_input.d
@@ -154,7 +154,7 @@ class CodeInput : TextInput {
             typeface.dpi = io.dpi;
 
             this.text.value = super.text.value;
-            text.indentWidth = indentWidth * typeface.advance(' ').x / io.hidpiScale.x;
+            text.indentWidth = indentWidth * typeface.advance(' ', style.fontSize).x / io.hidpiScale.x;
             text.resize(available);
             minSize = text.size;
 

--- a/source/fluid/grid.d
+++ b/source/fluid/grid.d
@@ -16,7 +16,7 @@ import fluid.structs;
 
 
 deprecated("Renamed to `gridFrame`") alias grid = simpleConstructor!Grid;
-alias gridFrame = grid;
+alias gridFrame = simpleConstructor!GridFrame;
 alias gridRow = simpleConstructor!GridRow;
 
 // TODO rename segments to columns?
@@ -29,7 +29,7 @@ struct Segments {
     uint amount = 1;
 
     /// Set the number of columns present in a grid.
-    void apply(Grid grid) {
+    void apply(GridFrame grid) {
 
         grid.segmentCount = amount;
 
@@ -82,7 +82,7 @@ class GridFrame : Frame {
         // Check the other arguments
         static foreach (i, arg; children) {{
 
-            // Grid row (via array)
+            // GridFramerow (via array)
             static if (is(typeof(arg) : U[], U)) {
 
                 this.children[i] = gridRow(this, arg);
@@ -368,14 +368,14 @@ class GridFrame : Frame {
 /// A single row in a `Grid`.
 class GridRow : Frame {
 
-    Grid parent;
+    GridFrame parent;
     size_t segmentCount;
 
     /// Params:
     ///     params = Standard Fluid constructor parameters.
-    ///     parent = Grid this row will be placed in.
+    ///     parent = GridFramethis row will be placed in.
     ///     nodes = Children to be placed in the row.
-    this(T...)(Grid parent, T nodes) {
+    this(T...)(GridFrame parent, T nodes) {
 
         super(nodes);
         this.layout.nodeAlign = NodeAlign.fill;

--- a/source/fluid/label.d
+++ b/source/fluid/label.d
@@ -25,7 +25,7 @@ class Label : Node {
 
     }
 
-    @property void textSize(T)(T size) {
+    @property void fontSize(T)(T size) {
         text.fontSize = cast(uint) size;
     }
 
@@ -35,22 +35,14 @@ class Label : Node {
 
     }
 
-    debug float cachedTextSize;
     this(string text, float size) {
-        debug cachedTextSize = size;
 
         this.text = Text!Label(this, text);
 
         theme = theme.derive(
-            rule(Rule.textSize = size)
+            rule(Rule.fontSize = size)
         );
         reloadStyles;
-
-        debug {
-            import std.stdio, std.conv;
-            writeln("textSize = ", size);
-            assert(this.style.textSize == size, "Textsize should be "~size.to!string~", instead it is "~style.textSize.to!string);
-        }
 
     }
 
@@ -96,11 +88,6 @@ class Label : Node {
         const style = pickStyle();
         style.drawBackground(tree.io, outer);
         text.draw(style, inner.start);
-
-        debug {
-            import std.conv, std.math.traits;
-            assert(style.textSize.isNaN || style.textSize == cachedTextSize, "style.textsize = "~this.style.textSize.to!string~", cachedTextSize = "~cachedTextSize.to!string);
-        }
 
     }
 

--- a/source/fluid/label.d
+++ b/source/fluid/label.d
@@ -25,6 +25,10 @@ class Label : Node {
 
     }
 
+    @property void textSize(T)(T size) {
+        text.fontSize = cast(uint) size;
+    }
+
     this(Rope text) {
 
         this.text = Text!Label(this, text);

--- a/source/fluid/label.d
+++ b/source/fluid/label.d
@@ -35,6 +35,25 @@ class Label : Node {
 
     }
 
+    debug float cachedTextSize;
+    this(string text, float size) {
+        debug cachedTextSize = size;
+
+        this.text = Text!Label(this, text);
+
+        theme = theme.derive(
+            rule(Rule.textSize = size)
+        );
+        reloadStyles;
+
+        debug {
+            import std.stdio, std.conv;
+            writeln("textSize = ", size);
+            assert(this.style.textSize == size, "Textsize should be "~size.to!string~", instead it is "~style.textSize.to!string);
+        }
+
+    }
+
     this(const(char)[] text) {
 
         this.text = Text!Label(this, text);
@@ -77,6 +96,11 @@ class Label : Node {
         const style = pickStyle();
         style.drawBackground(tree.io, outer);
         text.draw(style, inner.start);
+
+        debug {
+            import std.conv, std.math.traits;
+            assert(style.textSize.isNaN || style.textSize == cachedTextSize, "style.textsize = "~this.style.textSize.to!string~", cachedTextSize = "~cachedTextSize.to!string);
+        }
 
     }
 

--- a/source/fluid/password_input.d
+++ b/source/fluid/password_input.d
@@ -211,7 +211,7 @@ class PasswordInput : TextInput {
         // Ignore if selection is empty
         if (selectionStart == selectionEnd) return;
 
-        const typeface = style.getTypeface;
+        auto typeface = style.getTypeface;
 
         const low = min(selectionStart, selectionEnd);
         const high = max(selectionStart, selectionEnd);
@@ -221,7 +221,7 @@ class PasswordInput : TextInput {
 
         const rect = Rectangle(
             (inner.start + Vector2(start, 0)).tupleof,
-            size, typeface.lineHeight,
+            size, typeface.lineHeight(style.fontSize),
         );
 
         io.drawRectangle(rect, style.selectionBackgroundColor);
@@ -234,7 +234,7 @@ class PasswordInput : TextInput {
 
         // Use the "X" character as reference
         auto typeface = style.getTypeface;
-        auto x = typeface.advance('X').x;
+        auto x = typeface.advance('X', style.fontSize).x;
 
         radius = x / 2f;
         advance = x * 1.2;

--- a/source/fluid/style.d
+++ b/source/fluid/style.d
@@ -45,6 +45,9 @@ struct Style {
         /// Text color.
         Color textColor;
 
+        /// Text height.
+        float textSize;
+
     }
 
     // Background & content

--- a/source/fluid/style.d
+++ b/source/fluid/style.d
@@ -46,7 +46,8 @@ struct Style {
         Color textColor;
 
         /// Text height.
-        float textSize;
+        float fontSize = 14;
+        deprecated alias textSize = fontSize;
 
     }
 

--- a/source/fluid/text.d
+++ b/source/fluid/text.d
@@ -171,7 +171,7 @@ struct Text(T : Node, StyleRange = TextStyleSlice[]) {
         typeface.indentWidth = cast(int) (indentWidth * scale.x);
 
         // Update the size
-        _sizeDots = typeface.measure(value);
+        _sizeDots = typeface.measure(value, style.fontSize);
         _wrap = false;
         clearTextures();
 
@@ -192,7 +192,7 @@ struct Text(T : Node, StyleRange = TextStyleSlice[]) {
         space.y *= scale.y;
 
         // Update the size
-        _sizeDots = style.getTypeface.measure!splitter(space, value, wrap);
+        _sizeDots = style.getTypeface.measure!splitter(space, value, wrap, style.fontSize);
         _wrap = wrap;
         clearTextures();
 
@@ -312,7 +312,7 @@ struct Text(T : Node, StyleRange = TextStyleSlice[]) {
 
                         // Note: relativePenPosition is passed by ref
                         auto image = texture.chunks[chunkIndex].image;
-                        typeface.drawLine(image, relativePenPosition, wordFragment, styleIndex, cast(uint)(style.textSize*64));
+                        typeface.drawLine(image, relativePenPosition, wordFragment, styleIndex, style.fontSize);
 
                         // Update the pen position; Result of this should be the same for each chunk
                         penPosition = relativePenPosition + chunkRect.start;

--- a/source/fluid/text.d
+++ b/source/fluid/text.d
@@ -54,6 +54,9 @@ struct Text(T : Node, StyleRange = TextStyleSlice[]) {
         /// Indent width, in pixels.
         float indentWidth = 32;
 
+        /// Text size. Set to 0 for default size.
+        uint fontSize = 0;
+
     }
 
     private {
@@ -312,7 +315,7 @@ struct Text(T : Node, StyleRange = TextStyleSlice[]) {
 
                         // Note: relativePenPosition is passed by ref
                         auto image = texture.chunks[chunkIndex].image;
-                        typeface.drawLine(image, relativePenPosition, wordFragment, styleIndex);
+                        typeface.drawLine(image, relativePenPosition, wordFragment, styleIndex, fontSize);
 
                         // Update the pen position; Result of this should be the same for each chunk
                         penPosition = relativePenPosition + chunkRect.start;

--- a/source/fluid/text.d
+++ b/source/fluid/text.d
@@ -54,9 +54,6 @@ struct Text(T : Node, StyleRange = TextStyleSlice[]) {
         /// Indent width, in pixels.
         float indentWidth = 32;
 
-        /// Text size. Set to 0 for default size.
-        uint fontSize = 0;
-
     }
 
     private {
@@ -165,8 +162,8 @@ struct Text(T : Node, StyleRange = TextStyleSlice[]) {
     /// Set new bounding box for the text.
     void resize() {
 
-        auto style = node.pickStyle;
-        auto typeface = style.getTypeface;
+        Style style = node.pickStyle;
+        Typeface typeface = style.getTypeface;
         const dpi = backend.dpi;
         const scale = backend.hidpiScale;
 
@@ -183,8 +180,8 @@ struct Text(T : Node, StyleRange = TextStyleSlice[]) {
     /// Set new bounding box for the text; wrap the text if it doesn't fit in boundaries.
     void resize(alias splitter = Typeface.defaultWordChunks)(Vector2 space, bool wrap = true) {
 
-        auto style = node.pickStyle;
-        auto typeface = style.getTypeface;
+        Style style = node.pickStyle;
+        Typeface typeface = style.getTypeface;
         const dpi = backend.dpi;
         const scale = backend.hidpiScale;
 
@@ -226,8 +223,8 @@ struct Text(T : Node, StyleRange = TextStyleSlice[]) {
         // Empty, nothing to do
         if (chunks.empty) return;
 
-        auto style = node.pickStyle;
-        auto typeface = style.getTypeface;
+        Style style = node.pickStyle;
+        Typeface typeface = style.getTypeface;
         const dpi = backend.dpi;
         const scale = backend.hidpiScale;
 
@@ -315,7 +312,7 @@ struct Text(T : Node, StyleRange = TextStyleSlice[]) {
 
                         // Note: relativePenPosition is passed by ref
                         auto image = texture.chunks[chunkIndex].image;
-                        typeface.drawLine(image, relativePenPosition, wordFragment, styleIndex, fontSize);
+                        typeface.drawLine(image, relativePenPosition, wordFragment, styleIndex, cast(uint)(style.textSize*64));
 
                         // Update the pen position; Result of this should be the same for each chunk
                         penPosition = relativePenPosition + chunkRect.start;

--- a/source/fluid/text_input.d
+++ b/source/fluid/text_input.d
@@ -711,7 +711,7 @@ class TextInput : InputNode!Node, FluidScrollable {
         root.io = io;
         root.draw();
 
-        Vector2 textSize() {
+        Vector2 fontSize() {
 
             return root.contentLabel.minSize;
 
@@ -832,7 +832,7 @@ class TextInput : InputNode!Node, FluidScrollable {
 
                 decode(word[], index);  // index by reference
 
-                auto size = typeface.measure(word[0..index]);
+                auto size = typeface.measure(word[0..index], style.fontSize);
                 auto end = startPosition.x + size.x;
                 auto half = (match.position.x + end)/2;
 
@@ -962,6 +962,7 @@ class TextInput : InputNode!Node, FluidScrollable {
 
         auto typeface = style.getTypeface;
         auto ruler = textRuler();
+        ruler.fontSize = style.fontSize;
         auto slice = value[0 .. caretIndex + tail.length];
 
         // Measure text until the caret; include the word that follows to keep proper wrapping
@@ -970,7 +971,7 @@ class TextInput : InputNode!Node, FluidScrollable {
         auto caretPosition = ruler.caret.start;
 
         // Measure the word itself, and remove it
-        caretPosition.x -= typeface.measure(tail[]).x;
+        caretPosition.x -= typeface.measure(tail[], style.fontSize).x;
 
         return caretPosition;
 
@@ -1096,7 +1097,7 @@ class TextInput : InputNode!Node, FluidScrollable {
                 // Selection starts here
                 if (startIndex <= low && low <= endIndex) {
 
-                    const dent = typeface.measure(word[0 .. low - startIndex]);
+                    const dent = typeface.measure(word[0 .. low - startIndex], style.fontSize);
 
                     lineStart = caret.start + Vector2(dent.x, 0);
 
@@ -1105,7 +1106,7 @@ class TextInput : InputNode!Node, FluidScrollable {
                 // Selection ends here
                 if (startIndex <= high && high <= endIndex) {
 
-                    const dent = typeface.measure(word[0 .. high - startIndex]);
+                    const dent = typeface.measure(word[0 .. high - startIndex], FontSize.init);
                     const lineEnd = caret.end + Vector2(dent.x, 0);
                     const rect = Rectangle(
                         (inner.start + lineStart).tupleof,

--- a/source/fluid/typeface.d
+++ b/source/fluid/typeface.d
@@ -706,11 +706,14 @@ class FreetypeTypeface : Typeface {
 
         assert(_dpiX && _dpiY, "Font DPI hasn't been set");
 
+        debug import std.stdio;
         FT_Error setSizeError;
-        if (size == 0) {
+        if (!size) {
             setSizeError = FT_Set_Char_Size(cast(FT_FaceRec*) face, 0, _size*64, _dpiX, _dpiY);
+            debug writeln("Size is zero.");
         } else {
-            setSizeError = FT_Set_Char_Size(cast(FT_FaceRec*) face, 0, size*64, _dpiX, _dpiY);
+            setSizeError = FT_Set_Char_Size(cast(FT_FaceRec*) face, 0, size, _dpiX, _dpiY);
+            debug writeln("Size isn't zero.");
         }
         if (setSizeError) throw new Exception("Text size setting failed.");
 

--- a/tour/package.d
+++ b/tour/package.d
@@ -136,6 +136,7 @@ enum Chapter {
     @"Node slots" slots,
     @"Themes" themes,
     @"Margin, padding and border" margins,
+    @"Text styling" text_styling,
     @"Writing forms" forms,
     // @"Popups" popups,
     // @"Drag and drop" drag_and_drop,

--- a/tour/package.d
+++ b/tour/package.d
@@ -54,7 +54,7 @@ static this() {
             margin.sideX = 12,
             margin.sideY = 7,
         ),
-        rule!Grid(margin.sideY = 0),
+        rule!GridFrame(margin.sideY = 0),
         rule!GridRow(margin = 0),
         rule!ScrollFrame(margin = 0),
 
@@ -314,7 +314,7 @@ Space exampleList(void delegate(Chapter) @safe changeChapter) @safe {
     import std.array;
     import std.range;
 
-    auto chapterGrid = grid(
+    auto chapterGrid = gridFrame(
         .layout!"fill",
         .segments(3),
     );

--- a/tour/text_styling.d
+++ b/tour/text_styling.d
@@ -7,10 +7,10 @@ import fluid.tour;
 
 
 @(
-    () => label("For nodes that contain text, you can set the `textSize` style property to "
+    () => label("For nodes that contain text, you can set the `fontSize` style property to "
     ~ "change the height of the characters."),
 )
-Frame textSizeExample() {
+Frame fontSizeExample() {
     return vframe(
         label("Large text", 20f),
         label("Regular text", 12f),
@@ -23,14 +23,19 @@ Frame textSizeExample() {
     () => label("Ideally, you should make a theme with style tags for setting text sizes."),
 )
 Frame textTagsExample() {
+    enum TextStyle {
+        small,
+        large
+    }
+    
     Theme myTheme = Theme(
-        rule!(Label, 1)(textSize: 0.5f),
-        rule!(Label, 3)(textSize: 1.5f)
+        rule!(Label, TextStyle.small)(fontSize = 0.5f),
+        rule!(Label, TextStyle.large)(fontSize = 1.5f)
     );
     
     return vframe(
-        label("Large text", 2f),
-        label("Regular text", 16f),
-        label("Small text", 0.5f)
+        label(.tags!TextStyle.large, "Large text"),
+        label("Regular text"),
+        label(.tags!TextStyle.small, "Small text")
     );
 }*/

--- a/tour/text_styling.d
+++ b/tour/text_styling.d
@@ -1,0 +1,36 @@
+module fluid.tour.text_styling;
+
+import fluid;
+import fluid.tour;
+
+@safe:
+
+
+@(
+    () => label("For nodes that contain text, you can set the `textSize` style property to "
+    ~ "change the height of the characters."),
+)
+Frame textSizeExample() {
+    return vframe(
+        label("Large text", 20f),
+        label("Regular text", 12f),
+        label("Small text", 8f),
+        label("Default text")
+    );
+}
+/*
+@(
+    () => label("Ideally, you should make a theme with style tags for setting text sizes."),
+)
+Frame textTagsExample() {
+    Theme myTheme = Theme(
+        rule!(Label, 1)(textSize: 0.5f),
+        rule!(Label, 3)(textSize: 1.5f)
+    );
+    
+    return vframe(
+        label("Large text", 2f),
+        label("Regular text", 16f),
+        label("Small text", 0.5f)
+    );
+}*/


### PR DESCRIPTION
#158

This is to get custom sizing for text without having to make a new `TypeFace` object.

I know that I said earlier that this is probably something that you (@ArthaTi) should do, but I decided to begin attempting this.

So far I have a quick & dirty solution, but it hasn't been tested, so I don't know if it actually works.